### PR TITLE
moved damage calculation logic into a new function

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 let p1Dmg = 0;
 let p1HP = 0;
 let p1isKO = false;
+
 function isP1KO() {
     if (p1Dmg !== 0 && p1HP !== 0 && p1Dmg >= p1HP) {
         // alert('pokemon KO')
@@ -27,58 +28,57 @@ pokemon1HPDisplay.addEventListener('input', function () {
 })
 
 
+//4 damage control buttons for pokemon1
+
+//button adds 10 damage
 let incBtn = document.querySelector('#p1IncDmg');
 incBtn.addEventListener('click', function () {
-    if (p1HP > 0) {
-        p1Dmg += 10;
-        console.log(`p1 damage is now ${p1Dmg}`);
-        let damage = document.querySelector('span.damage');
-        damage.innerText = p1Dmg;
-        isP1KO();
-    }
-    else {
-        console.error('no damage, p1 hp is not set');
-        alert('Set the HP before adding damage');
-    }
+    p1Dmg = calcDamage(p1HP, p1Dmg, 10, '#p1DamageDisplay');
+    isP1KO();
 })
 
+//button adds 50 damage
 let incBtnFifty = document.querySelector('#p1IncDmgFifty')
 incBtnFifty.addEventListener('click', function () {
-    if (p1HP > 0) {
-        p1Dmg += 50;
-        console.log(`p1 damage is now ${p1Dmg}`);
-        let damage = document.querySelector('span.damage');
-        damage.innerText = p1Dmg;
-        isP1KO();
-    }
-    else {
-        console.error('no damage, p1 hp is not set');
-        alert('Set the HP before adding damage');
-    }
-
+    p1Dmg = calcDamage(p1HP, p1Dmg, 50, '#p1DamageDisplay');
+    isP1KO();
 })
 
+//button removes 10 damage
 let decBtn = document.querySelector('#p1DecDmg');
 decBtn.addEventListener('click', function () {
-    if (p1Dmg > 0) {
-        p1Dmg -= 10;
-        console.log(`damage is now ${p1Dmg}`);
-        let damage = document.querySelector('#p1DamageDisplay');
-        damage.innerText = p1Dmg;
-        isP1KO();
-    }
-    else {
-        console.error('damage cannot be less than zero');
-    }
+    p1Dmg = calcDamage(p1HP, p1Dmg, -10, '#p1DamageDisplay');
+    isP1KO();
 })
 
+//button clears all damage
 let clrBtn = document.querySelector('#p1ClrDmg');
 clrBtn.addEventListener('click', function () {
     p1Dmg = 0;
     console.log(`damage is now ${p1Dmg}`);
-    let damage = document.querySelector('span.damage');
-    damage.innerText = p1Dmg;
+    let damageDisplay = document.querySelector('#p1DamageDisplay');
+    damageDisplay.innerText = p1Dmg;
     isP1KO();
 })
 
-
+// This logic is called from the damage buttons: receives the pokemon HP, current damage, change in damage, and the the id for the span of the damage display
+// checks for HP not set, prevent damage from being negative, and of course returning the new damage
+function calcDamage(pHP, currentDmg, changeDmg, dmgSpanID) {
+    if (pHP === 0) {
+        console.error('No damage, hp is not set');
+        alert('Set the HP before adding damage');
+        newDmg = 0;
+        return newDmg
+    } else if (currentDmg === 0 && changeDmg < 0) {
+        console.error('Damage cannot be negative');
+        newDmg = 0;
+        return newDmg;
+    } else {
+        let newDmg = currentDmg + changeDmg;
+        console.log(`pokemon damage now ${newDmg}`);
+        console.log(dmgSpanID);
+        let damageDisplay = document.querySelector(dmgSpanID);
+        damageDisplay.innerText = newDmg;
+        return newDmg;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -46,13 +46,11 @@
                 <option value='220'>220</option>
                 <option value='230'>230</option>
             </select>
-
         </p>
-
         <p>Damage<span id='p1DamageDisplay' class='damage'>0</span></p>
-        <input class='button' id='p1IncDmgFifty' type="button" value="+ 50">
+        <input class='button incDmgFifty' id='p1IncDmgFifty' type="button" value="+ 50">
         <input class='button primaryDamage' id='p1IncDmg' type='button' value='+ 10'>
-        <input class='button' id='p1DecDmg' type='button' value='- 10'>
+        <input class='button decDmg' id='p1DecDmg' type='button' value='- 10'>
         <input class='button reset' id='p1ClrDmg' type='button' value='clear'>
     </div>
 


### PR DESCRIPTION
centralize the damage logic for no requiring HP to be set, no negative damage, and updating the display of damage.    This should reduce the amount of damage logic code repeated for 6 times the number of buttons in the future.

- [ ] hp must be set before adding damage
- [ ] damage cannot be negative
- [ ] KO style applies only when damage equals or exceeds the HP.