### PR TITLE
10 clean up some old references where the code is named to target a specific pokemon by number need to be renamed

### DIFF
--- a/app.js
+++ b/app.js
@@ -126,9 +126,9 @@ const extraPkmn = () => {
         field.push(testPkmn)
         console.log(field)
 
-        let pokemon1HPDisplay = document.querySelector(`#p${n}TotalHP`);
-        pokemon1HPDisplay.addEventListener('input', function () {
-            hpTotal = pokemon1HPDisplay.value;
+        let pokemonHPDisplay = document.querySelector(`#p${n}TotalHP`);
+        pokemonHPDisplay.addEventListener('input', function () {
+            hpTotal = pokemonHPDisplay.value;
             console.log(field)
             field[n - 1].hp = hpTotal
             console.log(`p${n} hp set to ${hpTotal}`)

--- a/app.js
+++ b/app.js
@@ -1,19 +1,19 @@
-function PKMN (id) {
+function PKMN(id) {
     this.id = id;
     this.name = "";
     this.hp = 0;
     this.active = 0;
     this.damage = 0;
     this.KO = 0;
-    }
-    
+}
+
 let field = []
 
 function isKO(pkmn, pkmnNbr) {
     if (pkmn.damage !== 0 && pkmn.hp !== 0 && pkmn.damage >= pkmn.hp) {
         // alert('pokemon KO')
         pkmn.KO = 1;
-        console.log('pokemon 1 is KO');
+        console.log(`pokemon ${pkmn.id} is KO`);
         document.querySelector(`#p${pkmnNbr}Card`).style.backgroundColor = 'pink';
         document.querySelector(`#p${pkmnNbr}CardHeader`).innerText = `Pokemon ${pkmnNbr} is KO`;
 
@@ -52,15 +52,15 @@ function calcDamage(pkmn, changeDmg, dmgSpanID) {
 
 let pkmnCount = 0;
 
-const extraPkmn = ()=>{
-    
-    if (pkmnCount<6){
+const extraPkmn = () => {
+
+    if (pkmnCount < 6) {
         pkmnCount++;
         const n = pkmnCount
-        let buttons = [{id: `p${n}IncDmgFifty`, class:"button", value:'+ 50'},
-                    {id: `p${n}IncDmg`, class:'button primaryDamage', value:'+ 10'},
-                    {id: `p${n}DecDmg`, class:'button', value:'- 10'},
-                    {id: `p${n}ClrDmg`, class:'button reset', value:'clear'}]
+        let buttons = [{ id: `p${n}IncDmgFifty`, class: "button", value: '+ 50' },
+        { id: `p${n}IncDmg`, class: 'button primaryDamage', value: '+ 10' },
+        { id: `p${n}DecDmg`, class: 'button', value: '- 10' },
+        { id: `p${n}ClrDmg`, class: 'button reset', value: 'clear' }]
         let card = document.createElement('div');
         card.className = 'card';
         card.id = `p${n}Card`;
@@ -82,10 +82,10 @@ const extraPkmn = ()=>{
         nameInput.type = 'text'
         pName.appendChild(nameInput);
         card.appendChild(pName);
-        
+
         let hpPara = document.createElement('p');
         hpLabel = document.createElement('label');
-        hpLabel.innerHTML= 'HP';
+        hpLabel.innerHTML = 'HP';
         hpLabel.htmlFor = `p${n}HP`;
         hpPara.appendChild(hpLabel);
         let hpSelect = document.createElement('select');
@@ -94,7 +94,7 @@ const extraPkmn = ()=>{
         hpDefault = document.createElement('option');
         hpDefault.innerHTML = '-Choose the HP';
         hpSelect.appendChild(hpDefault)
-        for (let i = 30; i<=280; i+=10){
+        for (let i = 30; i <= 280; i += 10) {
             tmpHP = document.createElement('option')
             tmpHP.value = `${i}`;
             tmpHP.innerHTML = `${i}`;
@@ -108,17 +108,17 @@ const extraPkmn = ()=>{
         dmgPara.setAttribute('class', 'damage')
         dmgPara.innerText = 'Damage: 0'
         //dmgPara.innerHTML = `Damage <span id='p${pkmnCount}DamageDisplay' class='damage'>0</span>`
-        
+
         card.appendChild(dmgPara);
         let dmgButtonPara = document.createElement('p')
-        for (let i = 0; i< buttons.length; i++){
-                tmpButton = document.createElement('input')
-                tmpButton.type = 'button'
-                tmpButton.setAttribute("class", buttons[i].class)
-                tmpButton.id = buttons[i].id
-                tmpButton.setAttribute("value", buttons[i].value)
-                dmgButtonPara.appendChild(tmpButton)
-            }
+        for (let i = 0; i < buttons.length; i++) {
+            tmpButton = document.createElement('input')
+            tmpButton.type = 'button'
+            tmpButton.setAttribute("class", buttons[i].class)
+            tmpButton.id = buttons[i].id
+            tmpButton.setAttribute("value", buttons[i].value)
+            dmgButtonPara.appendChild(tmpButton)
+        }
         card.appendChild(dmgButtonPara)
         cardDeck.appendChild(card);
 
@@ -130,31 +130,31 @@ const extraPkmn = ()=>{
         pokemon1HPDisplay.addEventListener('input', function () {
             hpTotal = pokemon1HPDisplay.value;
             console.log(field)
-            field[n-1].hp = hpTotal
+            field[n - 1].hp = hpTotal
             console.log(`p${n} hp set to ${hpTotal}`)
         })
         //button functions
-        
+
         // let hpTotal = 0
         // let damageCurrent = 0
         let incBtn = document.querySelector(`#p${n}IncDmg`);
         incBtn.addEventListener('click', function () {
-            calcDamage(field[n-1], 10, `#p${n}DamageDisplay`);
-            isKO(field[n-1], n);
+            calcDamage(field[n - 1], 10, `#p${n}DamageDisplay`);
+            isKO(field[n - 1], n);
         })
 
         //button adds 50 damage
         let incBtnFifty = document.querySelector(`#p${n}IncDmgFifty`)
         incBtnFifty.addEventListener('click', function () {
-            calcDamage(field[n-1], 50, `#p${n}DamageDisplay`);
-            isKO(field[n-1], n);
+            calcDamage(field[n - 1], 50, `#p${n}DamageDisplay`);
+            isKO(field[n - 1], n);
         })
 
         //button removes 10 damage
         let decBtn = document.querySelector(`#p${n}DecDmg`);
         decBtn.addEventListener('click', function () {
-            calcDamage(field[n-1], -10, `#p${n}DamageDisplay`);
-            isKO(field[n-1], n);
+            calcDamage(field[n - 1], -10, `#p${n}DamageDisplay`);
+            isKO(field[n - 1], n);
         })
 
         //button clears all damage
@@ -163,10 +163,10 @@ const extraPkmn = ()=>{
             console.log('damage is now 0');
             let damageDisplay = document.querySelector(`#p${n}DamageDisplay`);
             damageDisplay.innerText = 'Damage: 0';
-            field[n-1].damage = 0
-            isKO(field[n-1], n);
+            field[n - 1].damage = 0
+            isKO(field[n - 1], n);
         })
-        
+
     }
 }
 

--- a/app.js
+++ b/app.js
@@ -9,20 +9,20 @@ function PKMN(id) {
 
 let field = []
 
-function isKO(pkmn, pkmnNbr) {
+function isKO(pkmn) {
     if (pkmn.damage !== 0 && pkmn.hp !== 0 && pkmn.damage >= pkmn.hp) {
         // alert('pokemon KO')
         pkmn.KO = 1;
         console.log(`pokemon ${pkmn.id} is KO`);
-        document.querySelector(`#p${pkmnNbr}Card`).style.backgroundColor = 'pink';
-        document.querySelector(`#p${pkmnNbr}CardHeader`).innerText = `Pokemon ${pkmnNbr} is KO`;
+        document.querySelector(`#p${pkmn.id}Card`).style.backgroundColor = 'pink';
+        document.querySelector(`#p${pkmn.id}CardHeader`).innerText = `Pokemon ${pkmn.id} is KO`;
 
     }
     else {
         const remainingHP = pkmn.hp - pkmn.damage;
-        console.log(`pokemon ${pkmnNbr} has ${remainingHP} HP left`);
-        document.querySelector(`#p${pkmnNbr}Card`).style.backgroundColor = 'white';
-        document.querySelector(`#p${pkmnNbr}CardHeader`).innerText = `Pokemon ${pkmnNbr}`;
+        console.log(`pokemon ${pkmn.id} has ${remainingHP} HP left`);
+        document.querySelector(`#p${pkmn.id}Card`).style.backgroundColor = 'white';
+        document.querySelector(`#p${pkmn.id}CardHeader`).innerText = `Pokemon ${pkmn.id}`;
     }
 }
 
@@ -41,11 +41,10 @@ function calcDamage(pkmn, changeDmg, dmgSpanID) {
         return newDmg;
     } else {
         let newDmg = pkmn.damage + changeDmg;
-        console.log(`pokemon damage now ${newDmg}`);
-        console.log(dmgSpanID);
+        console.log(`pokemon ${pkmn.id} damage now ${newDmg}`);
         let damageDisplay = document.querySelector(dmgSpanID);
         damageDisplay.innerText = `Damage: ${newDmg}`;
-        pkmn.damage = newDmg
+        pkmn.damage = newDmg;
         return newDmg;
     }
 }
@@ -124,12 +123,10 @@ const extraPkmn = () => {
 
         let testPkmn = new PKMN(n)
         field.push(testPkmn)
-        console.log(field)
 
         let pokemonHPDisplay = document.querySelector(`#p${n}TotalHP`);
         pokemonHPDisplay.addEventListener('input', function () {
             hpTotal = pokemonHPDisplay.value;
-            console.log(field)
             field[n - 1].hp = hpTotal
             console.log(`p${n} hp set to ${hpTotal}`)
         })
@@ -140,31 +137,31 @@ const extraPkmn = () => {
         let incBtn = document.querySelector(`#p${n}IncDmg`);
         incBtn.addEventListener('click', function () {
             calcDamage(field[n - 1], 10, `#p${n}DamageDisplay`);
-            isKO(field[n - 1], n);
+            isKO(field[n - 1]);
         })
 
         //button adds 50 damage
         let incBtnFifty = document.querySelector(`#p${n}IncDmgFifty`)
         incBtnFifty.addEventListener('click', function () {
             calcDamage(field[n - 1], 50, `#p${n}DamageDisplay`);
-            isKO(field[n - 1], n);
+            isKO(field[n - 1]);
         })
 
         //button removes 10 damage
         let decBtn = document.querySelector(`#p${n}DecDmg`);
         decBtn.addEventListener('click', function () {
             calcDamage(field[n - 1], -10, `#p${n}DamageDisplay`);
-            isKO(field[n - 1], n);
+            isKO(field[n - 1]);
         })
 
         //button clears all damage
         let clrBtn = document.querySelector(`#p${n}ClrDmg`);
         clrBtn.addEventListener('click', function () {
-            console.log('damage is now 0');
+            console.log(`pokemon ${n} damage is now 0`);
             let damageDisplay = document.querySelector(`#p${n}DamageDisplay`);
             damageDisplay.innerText = 'Damage: 0';
             field[n - 1].damage = 0
-            isKO(field[n - 1], n);
+            isKO(field[n - 1]);
         })
 
     }

--- a/app.js
+++ b/app.js
@@ -128,7 +128,7 @@ const extraPkmn = () => {
         pokemonHPDisplay.addEventListener('input', function () {
             hpTotal = pokemonHPDisplay.value;
             field[n - 1].hp = hpTotal
-            console.log(`p${n} hp set to ${hpTotal}`)
+            console.log(`pokemon ${n} HP set to ${hpTotal}`)
         })
         //button functions
 


### PR DESCRIPTION
sorry for the weird branch name - it was created from an GH issue.

- [x] when a Pokemon is KO, the console print should indicate the correct pokemon # , instead of pokemon 1 is K
- [x] all other functionality is unchanged
- [x] no more code with the naming convention "p1...something" as we won't need to duplicate this code and rename it for each card

- [x] please review the is KO function, why do we need to pass the 2nd parameter "pkmnNbr"?   it looks like pkmn.id will give the same result.  If so we can simply further!  