### PR TITLE
change name input attribute autocomplete >>  off

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,6 +79,7 @@ const extraPkmn = () => {
         pName.appendChild(nameLabel);
         let nameInput = document.createElement('input');
         nameInput.setAttribute('class', 'name');
+        nameInput.setAttribute('autocomplete', 'off');
         nameInput.className = 'name';
         nameInput.id = `poke${n}Name`;
         nameInput.type = 'text'


### PR DESCRIPTION
this should fix the issue of prompting an autocomplete with the user's personal name into a pokemon name field.  

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete